### PR TITLE
Add blog.conf to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 
 # Ignore blog content
 /blog content
+
+# Ignore blog.conf file
+blog.conf


### PR DESCRIPTION
blog.conf is a config file and thus should not be contributed as a part
of the code
