### PR TITLE
Fix fatal bug in git pull

### DIFF
--- a/app/controllers/git_controller.rb
+++ b/app/controllers/git_controller.rb
@@ -21,7 +21,7 @@ class GitController < ApplicationController
   def update_repo(config)
     conf = get_config(config)
     if conf
-      if Dir.directory?("blog content/#{conf['branch']}")
+      if Dir.exist?("blog content/#{conf['branch']}")
         pull_repo(conf['repo'], conf['branch'])
       else
         clone_repo(conf['repo'], conf['branch'])


### PR DESCRIPTION
Somehow `Dir.directory?` was used instead of `Dir.exist?` not sure how.
This fixes a bug where attempting to use the `/git/pull` route would
cause a crash. This no longer happens...
