### PR TITLE
Fix the markdown renderer

### DIFF
--- a/app/helpers/blog_posts_helper.rb
+++ b/app/helpers/blog_posts_helper.rb
@@ -18,6 +18,11 @@ module BlogPostsHelper
   end
 
   def markdown_options
-    {} # TODO: get these from config
+    {
+        tables: true,
+        fenced_code_blocks: true,
+        autolink: true,
+        strikethrough: true
+    }
   end
 end


### PR DESCRIPTION
It now allows some things that are not set by
default, eg. fenced code blocks were not
rendering
